### PR TITLE
Fix Stale Share Rate Exploit in Staking Logic

### DIFF
--- a/programs/helix-staking/src/instructions/claim_rewards.rs
+++ b/programs/helix-staking/src/instructions/claim_rewards.rs
@@ -7,6 +7,7 @@ use crate::error::HelixError;
 use crate::events::RewardsClaimed;
 use crate::state::{GlobalState, StakeAccount};
 use crate::instructions::math::{calculate_pending_rewards, calculate_reward_debt, calculate_loyalty_bonus, mul_div};
+use crate::instructions::crank_distribution::distribute_pending_inflation;
 
 #[derive(Accounts)]
 pub struct ClaimRewards<'info> {
@@ -60,6 +61,10 @@ pub struct ClaimRewards<'info> {
 
 pub fn claim_rewards(ctx: Context<ClaimRewards>) -> Result<()> {
     let clock = Clock::get()?;
+
+    // Ensure share_rate is up-to-date
+    distribute_pending_inflation(&mut ctx.accounts.global_state, &clock)?;
+
     let global_state = &mut ctx.accounts.global_state;
     let stake = &ctx.accounts.stake_account;
 

--- a/programs/helix-staking/src/instructions/crank_distribution.rs
+++ b/programs/helix-staking/src/instructions/crank_distribution.rs
@@ -38,10 +38,27 @@ pub struct CrankDistribution<'info> {
 
 pub fn crank_distribution(ctx: Context<CrankDistribution>) -> Result<()> {
     let global_state = &mut ctx.accounts.global_state;
-
-    // Get current time
     let clock = Clock::get()?;
 
+    // Explicit check for manual crank to preserve error behavior
+    let current_day = get_current_day(
+        global_state.init_slot,
+        clock.slot,
+        global_state.slots_per_day,
+    )?;
+
+    require!(
+        current_day > global_state.current_day,
+        HelixError::AlreadyDistributedToday
+    );
+
+    distribute_pending_inflation(global_state, &clock)
+}
+
+/// Helper function to distribute pending inflation if a new day has started.
+/// This can be called safely from other instructions to ensure share_rate is up-to-date.
+/// It is idempotent (does nothing if already distributed for the day).
+pub fn distribute_pending_inflation(global_state: &mut GlobalState, clock: &Clock) -> Result<()> {
     // Calculate current day
     let current_day = get_current_day(
         global_state.init_slot,
@@ -49,11 +66,10 @@ pub fn crank_distribution(ctx: Context<CrankDistribution>) -> Result<()> {
         global_state.slots_per_day,
     )?;
 
-    // Require that we haven't already distributed for this day
-    require!(
-        current_day > global_state.current_day,
-        HelixError::AlreadyDistributedToday
-    );
+    // If already distributed for this day (or later?), do nothing
+    if current_day <= global_state.current_day {
+        return Ok(());
+    }
 
     // Calculate days elapsed since last distribution
     let days_elapsed = current_day

--- a/programs/helix-staking/src/instructions/create_stake.rs
+++ b/programs/helix-staking/src/instructions/create_stake.rs
@@ -7,6 +7,7 @@ use crate::error::HelixError;
 use crate::events::StakeCreated;
 use crate::state::{GlobalState, StakeAccount, ClaimConfig};
 use crate::instructions::math::{calculate_t_shares, calculate_reward_debt};
+use crate::instructions::crank_distribution::distribute_pending_inflation;
 
 #[derive(Accounts)]
 pub struct CreateStake<'info> {
@@ -56,6 +57,11 @@ pub fn create_stake<'info>(
     amount: u64,
     days: u16,
 ) -> Result<()> {
+    let clock = Clock::get()?;
+
+    // Ensure share_rate is up-to-date (sandwich attack prevention)
+    distribute_pending_inflation(&mut ctx.accounts.global_state, &clock)?;
+
     let global_state = &mut ctx.accounts.global_state;
     let stake_account = &mut ctx.accounts.stake_account;
 
@@ -70,9 +76,6 @@ pub fn create_stake<'info>(
         days >= 1 && days <= MAX_STAKE_DAYS as u16,
         HelixError::InvalidStakeDuration
     );
-
-    // Get current time
-    let clock = Clock::get()?;
 
     // Calculate T-shares with LPB + BPB bonuses
     let t_shares = calculate_t_shares(amount, days as u64, global_state.share_rate)?;

--- a/programs/helix-staking/src/instructions/unstake.rs
+++ b/programs/helix-staking/src/instructions/unstake.rs
@@ -6,6 +6,7 @@ use crate::error::HelixError;
 use crate::events::StakeEnded;
 use crate::state::{GlobalState, StakeAccount};
 use crate::instructions::math::{calculate_early_penalty, calculate_late_penalty, calculate_pending_rewards, calculate_loyalty_bonus, mul_div};
+use crate::instructions::crank_distribution::distribute_pending_inflation;
 
 #[derive(Accounts)]
 pub struct Unstake<'info> {
@@ -55,6 +56,10 @@ pub struct Unstake<'info> {
 
 pub fn unstake(ctx: Context<Unstake>) -> Result<()> {
     let clock = Clock::get()?;
+
+    // Ensure share_rate is up-to-date
+    distribute_pending_inflation(&mut ctx.accounts.global_state, &clock)?;
+
     let global_state = &mut ctx.accounts.global_state;
     let stake = &ctx.accounts.stake_account;
 


### PR DESCRIPTION
Implemented a fix for a potential stale share rate exploit in the Helix Staking protocol.
Refactored the `crank_distribution` logic into a reusable `distribute_pending_inflation` helper function.
Updated `create_stake`, `unstake`, and `claim_rewards` instructions to call this helper at the beginning of execution, ensuring the global share rate is up-to-date before any user interaction.
This prevents users from exploiting stale state to gain unfair rewards or dilute existing stakers.
Verified the changes compile correctly with `cargo check`.

---
*PR created automatically by Jules for task [11383537847469153463](https://jules.google.com/task/11383537847469153463) started by @ethan-hurst*